### PR TITLE
fix: missing system env vars to execute compilation command

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,6 +99,8 @@ export default class Go {
     const name = this.options.function;
     const func = this.serverless.service.functions[this.options.function];
 
+    this.logInfo(`Compilation time (${name}): ${prettyHrtime(timeEnd)}`);
+
     const timeStart = process.hrtime();
     await this.compile(name, func, false);
     const timeEnd = process.hrtime(timeStart);
@@ -184,7 +186,7 @@ export default class Go {
       env["GOARCH"] = "arm64";
     }
 
-    let execOpts = { cwd: cwd, env: env };
+    let execOpts = { cwd: cwd, env: { ...process.env, ...env } };
 
     try {
       await this.exec(command, execOpts);

--- a/index.test.js
+++ b/index.test.js
@@ -74,7 +74,10 @@ describe("Go Plugin", () => {
 
     expect(execStub).to.have.been.calledWith(
       `go build -ldflags="-s -w" -o .bin/testFunc2 functions/func2/main.go`,
-      { cwd: ".", env: { CGO_ENABLED: "0", GOOS: "linux" } },
+      {
+        cwd: ".",
+        env: { ...process.env, ...{ CGO_ENABLED: "0", GOOS: "linux" } },
+      },
     );
 
     expect(config.service.functions.testFunc3.handler).to.equal(
@@ -83,7 +86,10 @@ describe("Go Plugin", () => {
 
     expect(execStub).to.have.been.calledWith(
       `go build -ldflags="-s -w" -o .bin/testFunc3 functions/func3`,
-      { cwd: ".", env: { CGO_ENABLED: "0", GOOS: "linux" } },
+      {
+        cwd: ".",
+        env: { ...process.env, ...{ CGO_ENABLED: "0", GOOS: "linux" } },
+      },
     );
   });
 
@@ -113,7 +119,10 @@ describe("Go Plugin", () => {
     // then
     expect(execStub).to.have.been.calledOnceWith(
       `go build -o .bin/testFunc1 functions/func1/main.go`,
-      { cwd: ".", env: { CGO_ENABLED: "0", GOOS: "linux" } },
+      {
+        cwd: ".",
+        env: { ...process.env, ...{ CGO_ENABLED: "0", GOOS: "linux" } },
+      },
     );
   });
 
@@ -141,7 +150,13 @@ describe("Go Plugin", () => {
     // then
     expect(execStub).to.have.been.calledOnceWith(
       `go build -ldflags="-s -w" -o .bin/testFunc1 functions/func1/main.go`,
-      { cwd: ".", env: { CGO_ENABLED: "0", GOOS: "linux", GOARCH: "arm64" } },
+      {
+        cwd: ".",
+        env: {
+          ...process.env,
+          ...{ CGO_ENABLED: "0", GOOS: "linux", GOARCH: "arm64" },
+        },
+      },
     );
   });
 
@@ -171,7 +186,10 @@ describe("Go Plugin", () => {
     // then
     expect(execStub).to.have.been.calledOnceWith(
       `go build -ldflags="-s -w" -o ../.bin/testFunc1 functions/func1/main.go`,
-      { cwd: "gopath", env: { CGO_ENABLED: "0", GOOS: "linux" } },
+      {
+        cwd: "gopath",
+        env: { ...process.env, ...{ CGO_ENABLED: "0", GOOS: "linux" } },
+      },
     );
   });
 
@@ -245,7 +263,10 @@ describe("Go Plugin", () => {
     // then
     expect(execStub).to.have.been.calledOnceWith(
       `go build -ldflags="-s -w" -o .bin/testFunc1 functions/func1/main.go`,
-      { cwd: ".", env: { CGO_ENABLED: "0", GOOS: "linux" } },
+      {
+        cwd: ".",
+        env: { ...process.env, ...{ CGO_ENABLED: "0", GOOS: "linux" } },
+      },
     );
   });
 
@@ -284,7 +305,10 @@ describe("Go Plugin", () => {
 
     expect(execStub).to.have.been.calledWith(
       `go build -ldflags="-s -w" -o ../../.bin/testFunc1 .`,
-      { cwd: "functions/func1", env: { CGO_ENABLED: "0", GOOS: "linux" } },
+      {
+        cwd: "functions/func1",
+        env: { ...process.env, ...{ CGO_ENABLED: "0", GOOS: "linux" } },
+      },
     );
 
     expect(config.service.functions.testFunc2.handler).to.equal(
@@ -293,7 +317,10 @@ describe("Go Plugin", () => {
 
     expect(execStub).to.have.been.calledWith(
       `go build -ldflags="-s -w" -o ../../.bin/testFunc2 main.go`,
-      { cwd: "functions/func2", env: { CGO_ENABLED: "0", GOOS: "linux" } },
+      {
+        cwd: "functions/func2",
+        env: { ...process.env, ...{ CGO_ENABLED: "0", GOOS: "linux" } },
+      },
     );
   });
 


### PR DESCRIPTION
## Description

Compilation execution fails by missing system env vars

## Task Context

### What is the current behavior?

The plugin just add configuration envs and ommit system envs

### What is the new behavior?

For compilatrion execution the plugin merge system envs and override with configuration envs if some env is duplicated

### Additional Context

<!-- Add here any additional context you think is important. -->
