### PR TITLE
fix: concurrency overhead

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,24 @@ Default values:
 ```yaml
 custom:
   go:
-    baseDir: '.' # folder where go.mod file lives, if set `handler` property should be set relatively to that folder
-    binDir: '.bin' # target folder for binary files
-    cmd: 'go build -ldflags="-s -w"' # compile command
-    monorepo: false # if enabled, builds function every directory (useful for monorepo where go.mod is managed by each function
-    env: # environment variables used to compile binaries
+    # folder where go.mod file lives, if set `handler` property should be set relatively to that folder
+    baseDir: '.'
+
+    # Final target destination of the binary outputs
+    binDir: '.bin'
+
+    # Compile command that should be used to build binaries
+    cmd: 'go build -ldflags="-s -w"'
+
+    # If enabled, builds function every directory (useful for monorepo where go.mod is managed by each function
+    monorepo: false
+
+    # Number of concurrent process used to compile functions, you can fine tune this number to your needs.
+    # Alternatively you can use the env var `SP_GO_CONCURRENCY` to override this configuration
+    concurrency: 5
+
+    # Environment variables used to compile binaries
+    env:
       GOOS: 'linux' # Default compile OS
       CGO_ENABLED: '0' # By default CGO is disabled
 ```

--- a/index.test.js
+++ b/index.test.js
@@ -324,7 +324,7 @@ describe("Go Plugin", () => {
     );
   });
 
-  it("compiles Go functions", async () => {
+  it("Compiles Go functions", async () => {
     config.service.setFunctions({
       testFunc1: {
         name: "testFunc1",
@@ -345,5 +345,59 @@ describe("Go Plugin", () => {
     expect(config.service.functions.testFunc1.handler).to.equal(
       `.bin/testFunc1`,
     );
+  });
+
+  it("Should get concurrency config", async () => {
+    config.service.setFunctions({
+      testFunc1: {
+        name: "testFunc1",
+        runtime: "provided.al2",
+        handler: "functions/func2/main.go",
+      },
+    });
+
+    const plugin = new Go(config);
+
+    expect(plugin.config.concurrency).to.be.equal(
+      plugin.defaultConfig.concurrency,
+    );
+  });
+
+  it("Should get concurrency from env vars", async () => {
+    config.service.setFunctions({
+      testFunc1: {
+        name: "testFunc1",
+        runtime: "provided.al2",
+        handler: "functions/func2/main.go",
+      },
+    });
+
+    process.env["SP_GO_CONCURRENCY"] = "10";
+
+    const plugin = new Go(config);
+
+    expect(plugin.config.concurrency).to.be.equal(10);
+
+    delete process.env["SP_GO_CONCURRENCY"];
+  });
+
+  it("Should get default concurrency if env var can't be parsed", async () => {
+    config.service.setFunctions({
+      testFunc1: {
+        name: "testFunc1",
+        runtime: "provided.al2",
+        handler: "functions/func2/main.go",
+      },
+    });
+
+    process.env["SP_GO_CONCURRENCY"] = "something";
+
+    const plugin = new Go(config);
+
+    expect(plugin.config.concurrency).to.be.equal(
+      plugin.defaultConfig.concurrency,
+    );
+
+    delete process.env["SP_GO_CONCURRENCY"];
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "serverless-plugin-go",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-plugin-go",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
         "chalk": "^5.3.0",
+        "p-limit": "^5.0.0",
         "pretty-hrtime": "^1.0.3",
         "util": "^0.12.5"
       },
@@ -2796,6 +2797,31 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit/node_modules/yocto-queue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-locate": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "adm-zip": "^0.5.10",
     "chalk": "^5.3.0",
+    "p-limit": "^5.0.0",
     "pretty-hrtime": "^1.0.3",
     "util": "^0.12.5"
   },


### PR DESCRIPTION
## Description

Sets a limit of concurrent compile opertios to avoid event loop overhead and affect the performance of the compilation flow

## Task Context

### What is the current behavior?

- The compilation of the binaries was executed as a `Promise.all` list with no limit that causes a low performance when function list is large

### What is the new behavior?

- Compilation flow implements a process limit using the packagte `p-limit` to avoid event loop overhead.

### Additional Context

Package `p-limit`:
https://www.npmjs.com/package/p-limit
